### PR TITLE
add option to not get catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Originally a fork of https://github.com/fal-ai/dbt-cloud-action with additional 
 - rewritten from JS to TS to improve future maintenance
 
 This action lets you trigger a job run on [dbt Cloud](https://cloud.getdbt.com), wait for the results of the job and fetch the `run_results.json`, `manifest.json` and `catalog.json` artifacts.
+If your dbt cloud job does not generate docs, set `fetch_catalog: false`
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,11 @@ inputs:
     description: The github pull request id that triggered this job
     required: false
 
+  fetch_catalog:
+    description: Set whether or not to fetch catalog.json after job run.
+    required: false
+    default: "true"
+
 outputs:
   git_sha:
     description: "Repository SHA in which dbt Cloud Job ran"

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,10 +192,13 @@ async function getArtifacts(account_id: string, run_id: number): Promise<void> {
     `/accounts/${account_id}/runs/${run_id}/artifacts/run_results.json`,
   );
   const run_results = res.data;
-  const catalog = await dbt_cloud_api.get(
+  if (core.getBooleanInput("fetch_catalog")) {
+    const catalog = await dbt_cloud_api.get(
     `/accounts/${account_id}/runs/${run_id}/artifacts/catalog.json`,
-  );
-  const catalog_data = catalog.data;
+    );
+    const catalog_data = catalog.data;
+  }
+  
   const manifest = await dbt_cloud_api.get(
     `/accounts/${account_id}/runs/${run_id}/artifacts/manifest.json`,
   );
@@ -209,7 +212,9 @@ async function getArtifacts(account_id: string, run_id: number): Promise<void> {
   }
 
   fs.writeFileSync(`${dir}/run_results.json`, JSON.stringify(run_results));
-  fs.writeFileSync(`${dir}/catalog.json`, JSON.stringify(catalog_data));
+  if (core.getBooleanInput("fetch_catalog")) {
+    fs.writeFileSync(`${dir}/catalog.json`, JSON.stringify(catalog_data));
+  }
   fs.writeFileSync(`${dir}/manifest.json`, JSON.stringify(manifest_data));
 }
 


### PR DESCRIPTION
Thanks for this fork, discovered while also trying to cancel jobs when new commits are made. Just need this small change to account for jobs that do not generate docs (and therefore do not create the catalog.json artifact).

Never worked in TS before so apologies in advance. 