### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run ci-test
+
+      - run: npm audit --audit-level=high


### PR DESCRIPTION
Adds a basic CI workflow that runs on PRs and pushes to main:

- `npm run lint`
- `npm run ci-test`
- `npm audit --audit-level=high`

Note: the initial CI run on main will fail (lint is broken due to a minimatch/FlatCompat issue, and there are open CVEs). Both are fixed by #11 — merge this first, then #11 will pass CI cleanly.