### PR TITLE
chore: migrate action runtime from Node 20 to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,6 @@ outputs:
   run_id:
     description: "Run ID of the dbt Cloud Job that was triggered"
 runs:
-  using: node20
+  using: node24
   main: "dist/index.js"
   post: "dist/index.js"


### PR DESCRIPTION
## What
Moves the action off the `node20` runtime (which GitHub is [deprecating on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) and onto `node24`, with CI bumped to match.

Relevant issue: https://github.com/dbt-labs/dbt-cloud-job-action/issues/13

## Changes
- `action.yml`: `runs.using: node20` → `node24`
- `.github/workflows/ci.yml`: test on Node `24`, matching the runtime the action ships on

`package.json` `engines.node` is intentionally left at `>=20`. It only constrains building the action from source, and the toolchain runs fine on Node 20 — no reason to raise the floor for contributors.

No `dist/` rebuild: there are no source changes, only the runtime declaration and CI config.

## Notes
- Heads up: the `npm audit --audit-level=high` CI step already fails on `main`, independently of this change — recent advisories (a batch against `axios`, plus `undici`, `js-yaml`, and others) now match the currently pinned versions. Happy to open a separate PR for those if it'd be useful.
- Possible follow-up: run CI on a Node `20` + `24` matrix to keep the `engines` floor honest. Left out here to keep this change focused.

## Testing
`npm ci && npm run lint && npm run ci-test` all pass locally.
